### PR TITLE
Fix tbody warning

### DIFF
--- a/packages/opencollective-eyemail-components/src/actions.js
+++ b/packages/opencollective-eyemail-components/src/actions.js
@@ -12,13 +12,15 @@ class Actions extends React.Component {
   render() {
     return (
       <table width="100%" cellPadding={this.props.padding}>
-        <tr>
-          {React.Children.map(this.props.children, (child, index) => (
-            <td key={index} style={this.tdStyle()}>
-              {child}
-            </td>
-          ))}
-        </tr>
+        <tbody>
+          <tr>
+            {React.Children.map(this.props.children, (child, index) => (
+              <td key={index} style={this.tdStyle()}>
+                {child}
+              </td>
+            ))}
+          </tr>
+        </tbody>
       </table>
     );
   }


### PR DESCRIPTION
Fix the following warning about DOM nesting in `Actions`:

```
Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. Add a <tbody> to your code to match the DOM tree generated by the browser.
    in tr
    in table
    in Actions
    in td
    in tr
    in tbody
    in table
    in BaseBlock
    in center
    in div
    in CenteredBlock
    in td
    in tr
    in tbody
    in table
    in BaseBlock
    in Content
    in td (created by BaseBlock)
    in tr (created by BaseBlock)
    in tbody (created by BaseBlock)
    in table (created by BaseBlock)
    in BaseBlock (created by Container)
    in body (created by Container)
    in html (created by Container)
    in Container
    in div (created by Editor)
    in div (created by Editor)
    in form (created by Editor)
    in div (created by Editor)
    in div (created by Editor)
    in Editor (created by Resolver)
    in Resolver
```